### PR TITLE
Fix if running via API

### DIFF
--- a/script.py
+++ b/script.py
@@ -460,7 +460,7 @@ def output_modifier(string, state):
 
     global picture_response, params, character
     
-    character = state.get('character_menu',None)
+    character = state.get('character_menu','None')
 
     if not picture_response:
         return string

--- a/script.py
+++ b/script.py
@@ -460,7 +460,7 @@ def output_modifier(string, state):
 
     global picture_response, params, character
     
-    character = state['character_menu']
+    character = state.get('character_menu',None)
 
     if not picture_response:
         return string


### PR DESCRIPTION
- Add a fallback when getting the value of `character_menu` property from the Oobabooga `state`. Falls back to `None` to avoid runtime errors where the character is not specified when the extension is loaded and running via the API.